### PR TITLE
Bump GHC version to 8.10.6 (Stack LTS-18.7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ RUN curl -sSLo /usr/local/bin/stack https://github.com/commercialhaskell/stack/r
     chmod +x /usr/local/bin/stack
 
 RUN cd /tmp && \
-    curl -sSLo /tmp/ghc.tar.xz https://downloads.haskell.org/~ghc/8.10.4/ghc-8.10.4-x86_64-alpine3.10-linux-integer-simple.tar.xz && \
+    curl -sSLo /tmp/ghc.tar.xz https://downloads.haskell.org/~ghc/8.10.6/ghc-8.10.6-x86_64-alpine3.10-linux-integer-simple.tar.xz && \
     tar xf ghc.tar.xz && \
-    cd ghc-8.10.4-x86_64-unknown-linux && \
+    cd ghc-8.10.6-x86_64-unknown-linux && \
     ./configure --prefix=/usr/local && \
     make install && \
-    rm -rf /tmp/ghc.tar.xz /tmp/ghc-8.10.4-x86_64-unknown-linux
+    rm -rf /tmp/ghc.tar.xz /tmp/ghc-8.10.6-x86_64-unknown-linux


### PR DESCRIPTION
Hi, I've been using this Docker image to build a Stack based project for Alpine.

I noticed that as of Stack LTS-18.7, the Stack ghc version is now 8.10.6. 
It'd be a big help to me if you could build this image and upload it to Docker Hub, under `fpco/alpine-haskell-stack/8.10.4`.

This PR should probably also update the README, but I'm not sure if it's possible to tell what the correct sha256 hash should be prior to uploading. 

Thanks for maintaining this